### PR TITLE
Fix mixed content error

### DIFF
--- a/linting/templates/results.html
+++ b/linting/templates/results.html
@@ -133,7 +133,7 @@
     padding: 5px;
   }
 </style>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.5/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5/jquery.min.js"></script>
 <script>
   function isInProblemMode() {
     return $('#mode_problems:checked').val() == 'problems'


### PR DESCRIPTION
Fix mixed content error.
Mixed Content: The page at 'https://biblatex-linter.herokuapp.com/validate' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.5/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.