### PR TITLE
🔧 Dependabot: monthly schedule + grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
Sets Dependabot to a **monthly** schedule and groups all updates into a single PR per ecosystem (`all-dependencies` group). N dependency bumps now produce 1 CI run instead of N, reducing Dependabot-triggered Actions runs.

Ecosystems configured: pip (`/` — covers requirements.txt + Pipfile) + github-actions.